### PR TITLE
Fix oauth_entity resource not setting computed values properly

### DIFF
--- a/servicenow/client/client_oauth_entity.go
+++ b/servicenow/client/client_oauth_entity.go
@@ -7,8 +7,8 @@ const EndpointOAuthEntity = "oauth_entity.do"
 type OAuthEntity struct {
 	BaseResult
 	Name                 string `json:"name"`
-	ClientUUID           string `json:"client_uuid"`
-	ClientID             string `json:"client_id"`
+	ClientUUID           string `json:"client_uuid,omitempty"`
+	ClientID             string `json:"client_id,omitempty"`
 	AccessTokenLifespan  int    `json:"access_token_lifespan,string"`
 	RefreshTokenLifespan int    `json:"refresh_token_lifespan,string"`
 	RedirectURL          string `json:"redirect_url"`

--- a/servicenow/resources/resource_oauth_entity.go
+++ b/servicenow/resources/resource_oauth_entity.go
@@ -135,9 +135,7 @@ func resourceFromOAuthEntity(data *schema.ResourceData, oauthEntity *client.OAut
 func resourceToOAuthEntity(data *schema.ResourceData) *client.OAuthEntity {
 	oauthEntity := client.OAuthEntity{
 		Name:                 data.Get(oauthEntityName).(string),
-		ClientUUID:           data.Get(oauthEntityClientID).(string),
-		ClientID:             data.Get(oauthEntityClientID).(string),
-		AccessTokenLifespan:  data.Get(oauthEntityAccess).(int),
+		AccessTokenLifespan:  data.Get(oauthEntityAccessTokenLifespan).(int),
 		RefreshTokenLifespan: data.Get(oauthEntityRefreshTokenLifespan).(int),
 		RedirectURL:          data.Get(oauthEntityRedirectURL).(string),
 		LogoURL:              data.Get(oauthEntityLogoURL).(string),


### PR DESCRIPTION
fixes following error:
```
panic: interface conversion: interface {} is string, not int
2019-01-22T20:59:41.435Z [DEBUG] plugin.terraform-provider-servicenow: 
2019-01-22T20:59:41.435Z [DEBUG] plugin.terraform-provider-servicenow: goroutine 519 [running]:
2019-01-22T20:59:41.435Z [DEBUG] plugin.terraform-provider-servicenow: github.com/coveo/terraform-provider-servicenow/servicenow/resources.resourceToOAuthEntity(0xc0001e6f50, 0x1)
2019-01-22T20:59:41.435Z [DEBUG] plugin.terraform-provider-servicenow: 	/home/travis/gopath/src/github.com/coveo/terraform-provider-servicenow/servicenow/resources/resource_oauth_entity.go:140 +0x651
```